### PR TITLE
Disable `oldtime` feature for chrono dependancy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ bytesize = { version = "1.1", features = ["serde"] }
 c2-chacha = "0.3"
 cargo_metadata = "0.14.1"
 cfg-if = "1"
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "0.4.19", default_features=false, features = ["serde"] }
 clap = { version = "3.1.6", features = ["derive", "env"] }
 conqueue = "0.4.0"
 cpu-time = "1.0"


### PR DESCRIPTION
Rustsec found chrono crate to be insecure on its `oldtime` feature in version 0.4 as shown here at https://rustsec.org/advisories/RUSTSEC-2020-0071. I think not being able to get time in NEAR may result in collateral damage in DEFI contracts where they rely on timestamps. Hopefully, there is 0.5 version of chrono coming [here](https://github.com/chronotope/chrono/pull/969) and workaround exists. I just put the workaround in this PR and am willing to replace the old to new one. 